### PR TITLE
Added django 1.9 compatibility

### DIFF
--- a/epiced/widgets.py
+++ b/epiced/widgets.py
@@ -5,7 +5,10 @@ from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
 from django.utils.encoding import force_text
 from django.core.exceptions import ImproperlyConfigured
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError: # Django < 1.8 compatibility
+    from django.forms.util import flatatt
 import json
 
 DEFAULT_EPICEDITOR_CONFIG = {


### PR DESCRIPTION
The django.forms.util module has been renamed to django.forms.utils.